### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # vocalsalad
 
-[![Latest version](https://pypip.in/v/vocalsalad/badge.png)](https://pypi.python.org/pypi/vocalsalad/)
+[![Latest version](https://img.shields.io/pypi/v/vocalsalad.svg)](https://pypi.python.org/pypi/vocalsalad/)
 [![Build Status](https://travis-ci.org/asimihsan/vocalsalad.svg?branch=master)](https://travis-ci.org/asimihsan/vocalsalad)
 [![Code Health](https://landscape.io/github/asimihsan/vocalsalad/master/landscape.png)](https://landscape.io/github/asimihsan/vocalsalad/master)
 [![Coverage Status](https://coveralls.io/repos/asimihsan/vocalsalad/badge.png?branch=master)](https://coveralls.io/r/asimihsan/vocalsalad?branch=master)
 [![Requirements Status](https://requires.io/github/asimihsan/vocalsalad/requirements.png?branch=master)](https://requires.io/github/asimihsan/vocalsalad/requirements/?branch=master)
-[![License](https://pypip.in/license/vocalsalad/badge.png)](https://pypi.python.org/pypi/vocalsalad/)
+[![License](https://img.shields.io/pypi/l/vocalsalad.svg)](https://pypi.python.org/pypi/vocalsalad/)
 
 > Run long-running tasks on remote machines, and gather file-based
 artifacts.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20vocalsalad))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `vocalsalad`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.